### PR TITLE
Computing multiple trials for a cone mosaic 

### DIFF
--- a/isettools/rgc/tests/s_rgcGridNtrial.m
+++ b/isettools/rgc/tests/s_rgcGridNtrial.m
@@ -39,22 +39,42 @@ oi = oiCompute(oi,scene);
 cMosaic = coneMosaic;
 cMosaic.setSizeToFOV(fov);
 
-% cMosaic.emGenSequence(nMovements);
+%% New method for multiple cone trials when not an oiSequence
+% nMovements = 25; nTrials = 2;
+% emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
+% [coneAbsorptions, coneCurrent] = cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);
+
+% vcNewGraphWin; 
+% ieMovie(squeeze(coneAbsorptions(1,:,:,:)));
+% ieMovie(squeeze(coneAbsorptions(2,:,:,:)));
+% ieMovie(squeeze(coneCurrent(2,:,:,:)));
+% ieMovie(squeeze(coneCurrent(1,:,:,:)));
+
+%%
+
+
+%% Loop (old) method for multiple cone trials when not an oiSequence
+
+% Returns the same coneAbsorptions and coneCurrent
+%
 nMovements = 25; nTrials = 2;
 emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
 coneAbsorptions = zeros(nTrials,cMosaic.rows,cMosaic.cols,nMovements);
 coneCurrent     = zeros(size(coneAbsorptions));
 for ii=1:nTrials
-    cMosaic.compute(oi,'emPaths',emPaths,'currentFlag',true);
+    cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);
     coneAbsorptions(ii,:,:,:) = cMosaic.absorptions;
     coneCurrent(ii,:,:,:)     = cMosaic.current;
     emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
 end
 
-% We would like the returns to be nTrials x r x c x time with this
-% syntax, which emPaths is nTrials > 1.
-%
-%   [abs,curr] = cMosaic.compute(oi,'emPaths',emPaths,'currentFlag',true);
+% vcNewGraphWin;
+% ieMovie(squeeze(coneAbsorptions(1,:,:,:)));
+% ieMovie(squeeze(coneAbsorptions(2,:,:,:)));
+% ieMovie(squeeze(coneCurrent(2,:,:,:)));
+% ieMovie(squeeze(coneCurrent(1,:,:,:)));
+
+
 %
 %% Make the bipolar layer with just one mosaic 
 

--- a/isettools/rgc/tests/s_rgcGridNtrial.m
+++ b/isettools/rgc/tests/s_rgcGridNtrial.m
@@ -40,9 +40,9 @@ cMosaic = coneMosaic;
 cMosaic.setSizeToFOV(fov);
 
 %% New method for multiple cone trials when not an oiSequence
-% nMovements = 25; nTrials = 2;
-% emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
-% [coneAbsorptions, coneCurrent] = cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);
+nMovements = 25; nTrials = 2;
+emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
+[coneAbsorptions, coneCurrent] = cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);
 
 % vcNewGraphWin; 
 % ieMovie(squeeze(coneAbsorptions(1,:,:,:)));
@@ -57,16 +57,16 @@ cMosaic.setSizeToFOV(fov);
 
 % Returns the same coneAbsorptions and coneCurrent
 %
-nMovements = 25; nTrials = 2;
-emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
-coneAbsorptions = zeros(nTrials,cMosaic.rows,cMosaic.cols,nMovements);
-coneCurrent     = zeros(size(coneAbsorptions));
-for ii=1:nTrials
-    cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);
-    coneAbsorptions(ii,:,:,:) = cMosaic.absorptions;
-    coneCurrent(ii,:,:,:)     = cMosaic.current;
-    emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
-end
+% nMovements = 25; nTrials = 2;
+% emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
+% coneAbsorptions = zeros(nTrials,cMosaic.rows,cMosaic.cols,nMovements);
+% coneCurrent     = zeros(size(coneAbsorptions));
+% for ii=1:nTrials
+%     cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);
+%     coneAbsorptions(ii,:,:,:) = cMosaic.absorptions;
+%     coneCurrent(ii,:,:,:)     = cMosaic.current;
+%     emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
+% end
 
 % vcNewGraphWin;
 % ieMovie(squeeze(coneAbsorptions(1,:,:,:)));

--- a/scripts/s_LayersFace.m
+++ b/scripts/s_LayersFace.m
@@ -13,10 +13,6 @@ rdt = RdtClient('isetbio');
 rdt.crp('/resources/data/cmosaics');
 % rdt.listArtifacts('type','mat','print',true);
 
-% coneMosaicDataFace
-% For some reason, this opens the cMosaic.window.  I don't understand why.
-% This happens when we load the data that is downloaded in
-% rdtLoadWellKnownFileTypes.
 data      = rdt.readArtifact('coneMosaicDataFace', 'type', 'mat');
 cMosaic   = data.cMosaic;
 
@@ -71,7 +67,7 @@ nTrials = 1; rgcL.set('numberTrials',nTrials);
 
 % Every mosaic has its input and properties assigned so we should be able
 % to just run through all of them.
-rgcL = rgcL.compute('bipolarScale',50,'bipolarContrast',0.5);
+rgcL.compute('bipolarScale',50,'bipolarContrast',0.5);
 
 %%
 rgcL.window;

--- a/scripts/s_LayersTest.m
+++ b/scripts/s_LayersTest.m
@@ -75,7 +75,7 @@ nTrials = 1; rgcL.set('numberTrials',nTrials);
 
 % Every mosaic has its input and properties assigned so we should be able
 % to just run through all of them.
-rgcL = rgcL.compute('bipolarScale',50,'bipolarContrast',0.5);
+rgcL.compute('bipolarScale',50,'bipolarContrast',0.5);
 
 %%
 rgcL.window;


### PR DESCRIPTION
This fix allows us to calculate multiple trials using coneMosaic.compute() by setting the number of eye movement paths, as we do for bipolarMosaic and rgcMosaic computes.

Rather than the old method (looping), we can now calculate absorptions and current data using this call

    ...
    <generate oi here>
    ...
    nMovements = 25; nTrials = 2;
    emPaths    = cMosaic.emGenSequence(nMovements,'nTrials',nTrials);
    [coneAbsorptions, coneCurrent] = cMosaic.compute(oi,'emPath',emPaths,'currentFlag',true);

The returned absorptions and current are (nTrials x row x col x time).  The cMosaic object stores the last trial.  