### PR TITLE
emGenSequence now checks for cone size before making eye movement tra…

### DIFF
--- a/isettools/cones/@coneMosaic/emGenSequence.m
+++ b/isettools/cones/@coneMosaic/emGenSequence.m
@@ -80,11 +80,15 @@ pos = zeros(nFrames, 2);
 
 nTrialsPos = zeros(nTrials,nFrames,2);
 
+% define cone parameters needed to convert units of mm or deg to cones, and
+% vice versa
+params.w = obj.patternSampleSize(1); % cone size in m
+
 for nn=1:nTrials
     %% generate eye movement for tremor
     if emFlag(1)
         % Load parameters
-        amplitude  = emGet(em, 'tremor amplitude', 'cones/sample');
+        amplitude  = emGet(em, 'tremor amplitude', 'cones/sample', params);
         interval   = emGet(em, 'tremor interval');
         intervalSD = emGet(em, 'tremor interval SD');
         
@@ -110,8 +114,8 @@ for nn=1:nTrials
     % generate eye movement for drift
     if emFlag(2)
         % Load Parameters
-        speed     = emGet(em, 'drift speed', 'cones/sample');
-        speedSD   = emGet(em, 'drift speed SD', 'cones/sample');
+        speed     = emGet(em, 'drift speed', 'cones/sample', params);
+        speedSD   = emGet(em, 'drift speed SD', 'cones/sample', params);
         
         % Generate random move at each sample time
         theta = 360 * randn + 0.1 * (1 : nFrames)';
@@ -126,8 +130,8 @@ for nn=1:nTrials
         interval = emGet(em, 'msaccade interval');
         intervalSD = emGet(em, 'msaccade interval SD');
         dirSD = emGet(em, 'msaccade dir SD', 'deg');
-        speed = emGet(em, 'msaccade speed', 'cones/sample');
-        speedSD = emGet(em, 'msaccade speed SD', 'cones/sample');
+        speed = emGet(em, 'msaccade speed', 'cones/sample', params);
+        speedSD = emGet(em, 'msaccade speed SD', 'cones/sample', params);
         
         % Compute microsaccade occurence times
         t = interval + randn(nFrames, 1) * intervalSD;


### PR DESCRIPTION
…ces. otherwise the scale of eye movements is wrong whenever the cone spacing differs from the default

``` Matlab
cMosaic     = coneMosaic('center', [0  0]);
em          = emCreate;

figure
% Tremor
em.emFlag   = [1 0 0];
emPaths     = cMosaic.emGenSequence(10000, 'nTrials', 1,'em', em);
plot(squeeze(emPaths(1,:,1)));

hold on
cMosaic     = coneMosaic('center', [.002 0]);
em          = emCreate;
emPaths     = cMosaic.emGenSequence(10000, 'nTrials', 1,'em', em);
plot(squeeze(emPaths(1,:,1)));

title('Tremor'); legend('Fovea', '6º periphery')
xlabel('Time (ms)')
ylabel('Position (number of cones)')
```


Using new branch
![screen shot 2017-08-29 at 4 06 57 pm](https://user-images.githubusercontent.com/2119646/29841702-734228f0-8cd4-11e7-9fd6-d0d2cedba6d4.png)


Using Master branch
![screen shot 2017-08-29 at 4 06 13 pm](https://user-images.githubusercontent.com/2119646/29841710-8021bab8-8cd4-11e7-9f5d-34a33fe94f07.png)


