### PR TITLE
Mean illuminance

### DIFF
--- a/isettools/opticalimage/optics/opticsSet.m
+++ b/isettools/opticalimage/optics/opticsSet.m
@@ -74,8 +74,16 @@ switch parm
         optics.type = val;
         
     case {'model','opticsmodel'}
-        % Valid choices are 
-        % The case and spaces do not matter.
+        % Set the optics model type
+        %
+        % diffractionlimited and shiftinvariant are the legitimate options.
+        % For consistency with ISET, and planning for the future of TL's
+        % EyeModeling implementation, we allow 'raytrace' but rename it to
+        % shiftinvariant.  At some point, we will allow raytrace as a
+        % legitimate name on its own.
+        
+        % The case and spaces in val do not matter.
+        if strcmp(val,'raytrace'), val = 'shiftinvariant'; end
         valid = {'diffractionlimited', 'shiftinvariant'};
         if validatestring(ieParamFormat(val), valid)
             optics.model = ieParamFormat(val);


### PR DESCRIPTION
In the opticalImage we have a slot for the mean illuminance (oi.data.meanIll).  I think we should delete the meanill slot and always calculate it on the fly.

I deleted the variable (mostly) in this branch.  At least it is my intention to delete it.  Doing so breaks the validation a bit - none of the numerical values are wrong but there are some checks about the number of fields in some structs.  The field counts no longer match up because, well, I deleted the meanIll.

So, I am hoping that one of the pros at Penn might confirm this and run a new set of validation data, ultimately merging this pull request.

Thanks,
Brian