### PR TITLE
Code updates to support custom oi padding

### DIFF
--- a/isettools/opticalimage/oiMakeEvenRowCol.m
+++ b/isettools/opticalimage/oiMakeEvenRowCol.m
@@ -32,11 +32,14 @@ if notDefined('sDist')
     sDist = sceneGet(scene, 'distance'); 
 end
 
+% Determine padSize and padParams
+[padSize, padValue] = oiPadParams(oi);
+
 sz = oiGet(oi, 'size');
 
 if isodd(sz(1)), padSize(1) = 1; end
 if isodd(sz(2)), padSize(2) = 1; end
 
-oi = oiPad(oi, [padSize 0], sDist, 'post');
+oi = oiPad(oi, [padSize 0], padValue, sDist, 'post');
 
 end

--- a/isettools/opticalimage/oiPadParams.m
+++ b/isettools/opticalimage/oiPadParams.m
@@ -1,0 +1,72 @@
+function [padSize, padValue] = oiPadParams(oi)
+% Determine the padSize, padValue padding params from the oi.pad struct
+%
+% Syntax:
+%   [padSize, padValue] = oiPadParams(oi)
+%
+% Description:
+%    Determine the padSize, padValue padding params from the oi.pad struct
+%    if the oi.pad has been set using an oi = oiSet(oi, 'pad', padStruct);
+%    Otherwise, select the defaults:
+%       - padSize  = imSize/8
+%       - padValue = 'meanphotons'
+%
+% Inputs:
+%    oi        - Struct. An optical image structure
+%
+% Outputs:
+%    padSize   - Matrix.  A matrix containing the dimensions to pad out.
+%    padValue  - String.  How to pad. See validatePadStruct() for valid padValue values
+%
+% Optional key/value pairs:
+%    None.
+%
+% History:
+%    10/01/18 npc  Wrote it
+%
+
+    % Default pad size
+    imSize = oiGet(oi, 'size');
+    padSizeDefault  = [round(imSize / 8) 0];
+    padValueDefault = 'mean photons';
+    
+    if (~isfield(oi, 'pad'))
+        padSize = padSizeDefault;
+        padValue = padValueDefault;
+        return;
+    end
+    
+    if (isfield(oi.pad, 'sizeDegs'))
+        % Convert pad size in degs to pad size in pixels
+        oiHorizontalFOVdegs = oiGet(oi, 'hfov');
+        cols = oiGet(oi, 'cols');
+        sampleSizeDegs = oiHorizontalFOVdegs/cols;
+        extraCols = ceil(0.5*(oi.pad.sizeDegs - oiHorizontalFOVdegs)/sampleSizeDegs);
+        
+        oiVerticalFOVdegs = oiGet(oi, 'vfov');
+        rows = oiGet(oi, 'rows');
+        sampleSizeDegs = oiVerticalFOVdegs/rows;
+        extraRows = ceil(0.5*(oi.pad.sizeDegs - oiVerticalFOVdegs)/sampleSizeDegs);
+
+        
+        % pad size in pixels. If new padSize is < pad size, switch to
+        % default pad size
+        padSize = [...
+            max([padSizeDefault(1) extraRows]) ...
+            max([padSizeDefault(2) extraCols])...
+            padSizeDefault(3) ...
+            ];
+
+    else
+        % Default behavior
+        padSize = padSizeDefault;
+    end
+    
+    if (isfield(oi.pad, 'value'))
+        padValue = oi.pad.value;
+    else
+        % Default behavior
+        padValue = padValueDefault;
+    end
+
+end

--- a/isettools/opticalimage/oiSet.m
+++ b/isettools/opticalimage/oiSet.m
@@ -169,7 +169,17 @@ switch parm
 
     case {'pad'}
         % Struct specifying the border-padding of the oi
-        oi.pad = validatePadStruct(val);
+        oi.pad = oiValidatePadStruct(val);
+        
+    case {'padvalue'}
+        % padding value, see oiValidatePadStruct for valid values
+        oi.pad.value = val;
+        oiValidatePadStruct(oi.pad);
+        
+    case {'padsizedegs'}
+        % padding size in visual degrees
+        oi.pad.sizeDegs = val;
+        oiValidatePadStruct(oi.pad);
         
     case {'wangular', 'widthangular', 'fov', ...
             'hfov', 'horizontalfieldofview'}

--- a/isettools/opticalimage/oiSet.m
+++ b/isettools/opticalimage/oiSet.m
@@ -100,6 +100,7 @@ function oi = oiSet(oi, parm, val, varargin)
     oi = oiSet(oi, 'filename', 'test')
     oi = oiSet(oi, 'optics', optics)
     oi = oiSet(oi, 'optics fnumber', 2.8);
+    oi = oiSet(oi, 'pad', struct('sizeDegs', 1.0, 'value', 'mean photons'));
     oiGet(oi, 'optics fnumber')
 %}
 
@@ -166,6 +167,10 @@ switch parm
         % Positive for scenes, negative for optical images
         oi.distance = val;
 
+    case {'pad'}
+        % Struct specifying the border-padding of the oi
+        oi.pad = validatePadStruct(val);
+        
     case {'wangular', 'widthangular', 'fov', ...
             'hfov', 'horizontalfieldofview'}
         oi.wAngular = val;

--- a/isettools/opticalimage/oiValidatePadStruct.m
+++ b/isettools/opticalimage/oiValidatePadStruct.m
@@ -1,8 +1,8 @@
-function pad = validatePadStruct(pad)
+function pad = oiValidatePadStruct(pad)
 
 % Define valid pad values
 validPadValues = {'mean photons', 'zero photons'};
-    
+
 % Ensure that the pad is a struct
 assert(isstruct(pad), '''pad'' argument must be a struct');
 
@@ -13,5 +13,4 @@ if (isfield(pad, 'value'))
     assert(ismember(pad.value, {'mean photons', 'zero photons'}), ...
         sprintf('valid values for pad.value are: {''%s'' ''%s''}', validPadValues{1}, validPadValues{2}));
 end
-
 end

--- a/isettools/opticalimage/optics/opticsOTF.m
+++ b/isettools/opticalimage/optics/opticsOTF.m
@@ -111,11 +111,13 @@ wave = oiGet(oi, 'wave');
 
 % Pad the optical image to allow for light spread. Also, make sure the row
 % and col values are even.
-imSize   = oiGet(oi, 'size');
-padSize  = round(imSize / 8);
-padSize(3) = 0;
+
+% Determine padSize and padParams
+[padSize, padValue] = oiPadParams(oi);
+
+
 sDist = sceneGet(scene, 'distance');
-oi = oiPad(oi, padSize, sDist);
+oi = oiPad(oi, padSize, padValue, sDist);
 
 % See s_FFTinMatlab to understand the logic of the operations here. We used
 % to do this one wavelength at a time. But this could cause dynamic range
@@ -166,3 +168,4 @@ end
 oi = oiSet(oi, 'photons', p);
 
 end
+

--- a/isettools/opticalimage/validatePadStruct.m
+++ b/isettools/opticalimage/validatePadStruct.m
@@ -1,0 +1,17 @@
+function pad = validatePadStruct(pad)
+
+% Define valid pad values
+validPadValues = {'mean photons', 'zero photons'};
+    
+% Ensure that the pad is a struct
+assert(isstruct(pad), '''pad'' argument must be a struct');
+
+
+% Ensure that if pad.value exists, it has a valid value
+if (isfield(pad, 'value'))
+    assert(ischar(pad.value), 'pad.value must be a string');
+    assert(ismember(pad.value, {'mean photons', 'zero photons'}), ...
+        sprintf('valid values for pad.value are: {''%s'' ''%s''}', validPadValues{1}, validPadValues{2}));
+end
+
+end


### PR DESCRIPTION
I have updated isetbio to allow for custom padding of the oi.

1. The **default behavior** is the old one, which is 
- padding using the mean photons in the oi, and 
- a padding region equal to 1/8 of the original oi width.

2. The updated code allows for a custom padding region (specified in degrees) and a custom padding value. Valid padding values at the moment are : {'mean photons', 'zero photons'}.  'mean photons' gives the old behavior, 'zero photons'  results in padding with zeros. The code checks for the user-supplied padding value and throws an error if an invalid value is passed.

Here is a code snippet showing how you can specify custom padding.
~~~
oi = oiCreate();
% Create a padding struct specifying that the oi should be padded 
% to a total width of 1.5 deg with a padding value equal to zero photons.
padStruct = struct(...
   'sizeDegs', 1.5,...
   'value', 'zero photons');
oi =  oiSet(oi, 'pad', padStruct);
oi = oiCompute(oi, scene);
~~~

3a. If a padStruct is passed and the 'sizeDegs' field is missing, we get the default width.
3b. If a padStruct is passed and the 'value' field is missing, we get the default padding value.
3c. If the supplied 'sizeDegs' results in a padding width which is smaller than the default padding width, the default width is used instead. At the moment, no message is returned to the user regarding this choice, but we can change this.

4. All validations in isetbio and IBIOColorDetect pass.