### PR TITLE
Merging 2dotfangle - analyzing the impact of defocus on the MTF

### DIFF
--- a/external/psychtoolbox/PsychColorimetricData/RetinalEccentricityMMToDegrees.m
+++ b/external/psychtoolbox/PsychColorimetricData/RetinalEccentricityMMToDegrees.m
@@ -26,36 +26,40 @@ function eccDegrees = RetinalEccentricityMMToDegrees(eccMm,species,method,eyeLen
 % These curves, I think, were produced by ray tracing or otherwise solving
 % model eyes.
 % 
-% The default eye length returned by EyeLength for Human is currently the Rodiek value of
-% 16.1 mm.  Drasdo and Fowler formulae are based on a length of about this, 
-% so the linear and DaceyPeterson methods are roughly consistent for small
-% angles.  Similarly with the Rhesus default.  Using other EyeLength's will
-% make the two methods inconsistent.
+% The default eye length returned by EyeLength for Human is currently
+% the Rodiek value of 16.1 mm.  Drasdo and Fowler formulae are based
+% on a length of about this, so the linear and DaceyPeterson methods
+% are roughly consistent for small angles.  Similarly with the Rhesus
+% default.  Using other EyeLength's will make the two methods
+% inconsistent.
 %
 % The Dacey and Peterson equations don't go through (0,0), but rather
 % produce a visual angle of 0.1 degree for an eccentricity of 0.  This
 % seems bad to me. I modified the formulae so that they use the linear
-% approximation for small angles, producing a result that does go through
-% (0,0).  This may be related to the fact that there is some ambiguity in
-% the papers between whether the center should be thought of as the fovea
-% or the center of the optical axis.  But I think this difference is small
-% enough that the same formulae would apply across such a shift in origin.
+% approximation for small angles, producing a result that does go
+% through (0,0).  This may be related to the fact that there is some
+% ambiguity in the papers between whether the center should be thought
+% of as the fovea or the center of the optical axis.  But I think this
+% difference is small enough that the same formulae would apply across
+% such a shift in origin.
 %
 % I digitized Drasdo and Fowler Figure 2 and compared it to what
-% DegreesToRetinalEccentricity produces.  I'd call agreement so-so, but
-% considerably better than what the linear approximation produces.  One
-% could probably do better, but my intuition is that the deviations are
-% small compared to eye to eye differences and differences that would be
-% produced by different model eyes, so that juice isn't worth the squeeze.
-% I pasted my digitization at the end of DegreesToRetinalEccentricity if
-% anyone wants to fuss with this.  But probably if you're going to do that,
-% you should do the whole ray tracing thing with our best current model
-% eye.
+% DegreesToRetinalEccentricity produces.  I'd call agreement so-so,
+% but considerably better than what the linear approximation produces.
+% One could probably do better, but my intuition is that the
+% deviations are small compared to eye to eye differences and
+% differences that would be produced by different model eyes, so that
+% juice isn't worth the squeeze. I pasted my digitization at the end
+% of DegreesToRetinalEccentricity if anyone wants to fuss with this.
+% But probably if you're going to do that, you should do the whole ray
+% tracing thing with our best current model eye.
 %
 % I have not checked the fit to the Perrry and Cowey curve for Rhesus
 % against a digitization of that figure.
 %
-% See also: EyeLength, DegreesToRetinalEccentricityMM, DegreesToRetinalMM, RetinalMMToDegrees
+% See also: 
+%  EyeLength, DegreesToRetinalEccentricityMM, DegreesToRetinalMM, 
+%     RetinalMMToDegrees
 %
 % 6/30/2015  dhb  Wrote it.
 

--- a/external/psychtoolbox/PsychColorimetricData/RetinalMMToDegrees.m
+++ b/external/psychtoolbox/PsychColorimetricData/RetinalMMToDegrees.m
@@ -22,10 +22,11 @@ function degs = RetinalMMToDegrees(mm,eyeLengthMM,fulltrig)
 % with DegreesToRetinalMM.  Nor does it account for the shape and optics of
 % the eye.
 % 
-% Routine EyeLength returns posterior nodal eye lengths for various species
-% and sources.  Use 'Human' and 'Rodieck' to get the eye lenght implicit in
-% RetinalEccentricityMMToDegrees and DegreesToRetinalEccentricityMM for
-% human, and similarly 'Rhesus' and 'PerryCowey' for rhesus.
+% Routine EyeLength returns posterior nodal eye lengths for various
+% species and sources.  Use 'Human' and 'Rodieck' to get the eye
+% length implicit in RetinalEccentricityMMToDegrees and
+% DegreesToRetinalEccentricityMM for human, and similarly 'Rhesus' and
+% 'PerryCowey' for rhesus.
 %
 % See also: DegreesToRetinalMM, EyeLength, RetinalEccentricityMMToDegrees, DegreesToRetinalEccentricityMM
 %

--- a/isettools/opticalimage/optics/opticsCreate.m
+++ b/isettools/opticalimage/optics/opticsCreate.m
@@ -1,8 +1,8 @@
-function optics = opticsCreate(opticsType, varargin)
+function [optics, wvfP] = opticsCreate(opticsType, varargin)
 % Create an optics structure
 %
 % Syntax:
-%   optics = OPTICSCREATE(opticsType, varargin)
+%   [optics, wvf] = OPTICSCREATE(opticsType, varargin)
 %
 % Description:
 %    This function is typically called through oiCreate. The optics
@@ -48,6 +48,7 @@ function optics = opticsCreate(opticsType, varargin)
 %
 % Outputs:
 %    optics     - Struct. The created optics structure.
+%    wvf        - If a wavefront optics model, the wvf struct is returned
 %
 % Optional key/value pairs:
 %    **Needs to be filled out**

--- a/isettools/wavefront/wvf/wvfGet.m
+++ b/isettools/wavefront/wvf/wvfGet.m
@@ -722,10 +722,11 @@ switch (parm)
     case {'psfspatialsamples', 'samplesspace', 'supportspace', ...
             'spatialsupport'}
         % wvfGet(wvf, 'samples space', 'um', wList)
-        % Spatial support in samples, centered on 0
-        % Unit and wavelength must be specified
-        % Should call case below to get one val, and then scale up by
-        % number of pixels.
+        %
+        %  Spatial support in samples, centered on 0
+        %  Unit and wavelength must be specified
+        %  Should call case below to get one val, and then scale up by
+        %  number of pixels.
         
         % This parameter matters for the OTF and PSF quite a bit. It
         % is the number of um per degree on the retina.
@@ -738,9 +739,17 @@ switch (parm)
         % Get the angular samples in degrees
         val = wvfGet(wvf, 'psf angular samples', 'deg', wave);
         
-        % Convert to meters and then to selected spatial scale
-        val = val * mPerDeg;  % Sample in meters
-        val = val * ieUnitScaleFactor(unit);
+        %{
+         % The next few lines are the previous code, I think it is in
+         % error.  When we ask for the samples in degrees, this will produce
+         % the wrong result.  We should only call this code for unit
+         %             nm um mm cm m km in ft
+         %  When the units are min or sec we should do something else!
+        
+         % Convert to meters and then to selected spatial scale 
+         val = val * mPerDeg;  % Sample in meters 
+         val = val * ieUnitScaleFactor(unit);
+        %}
         
     case {'psfspatialsample'}
         % This parameter matters for the OTF and PSF quite a bit. It

--- a/isettools/wavefront/wvf/wvfGet.m
+++ b/isettools/wavefront/wvf/wvfGet.m
@@ -730,7 +730,6 @@ switch (parm)
         
         % This parameter matters for the OTF and PSF quite a bit. It
         % is the number of um per degree on the retina.
-        mPerDeg = (wvfGet(wvf,'um per degree') * 10^-6);
         unit = 'deg';
         wave = wvfGet(wvf, 'calc wave');
         if ~isempty(varargin), unit = varargin{1}; end
@@ -750,6 +749,20 @@ switch (parm)
          val = val * mPerDeg;  % Sample in meters 
          val = val * ieUnitScaleFactor(unit);
         %}
+        switch unit
+            case {'nm', 'um', 'mm', 'cm', 'm', 'km', 'in', 'ft'}
+                mPerDeg = (wvfGet(wvf,'um per degree') * 10^-6);
+                val = val * mPerDeg;  % Sample in meters
+                val = val * ieUnitScaleFactor(unit);
+            case {'min'}
+                val = val*60;
+            case {'sec'}
+                val = val*60*60;
+            case {'deg'}
+                % Leave it alone
+            otherwise
+                error('Bad unit for samples space, %s', unit);
+        end
         
     case {'psfspatialsample'}
         % This parameter matters for the OTF and PSF quite a bit. It

--- a/isettools/wavefront/wvf/wvfPlot.m
+++ b/isettools/wavefront/wvf/wvfPlot.m
@@ -14,8 +14,8 @@ function [uData, pData, fNum] = wvfPlot(wvfP, pType, varargin)
 %      wvf = wvfCreate;
 %      wvf = wvfComputePSF(wvf); 
 %      wave = wvfGet(wvf, 'measured wavelength');
-%      + 2d psf angle - mesh. wvfPlot(wvf, '2d psf angle', 'min', [], wave)
-%      + 2d psf space - mesh  wvfPlot(wvf, '2d psf space', 'um', wave, 10)
+%      + psf angle - mesh. wvfPlot(wvf, 'psf angle', 'min', [], wave)
+%      + psf space - mesh  wvfPlot(wvf, 'psf space', 'um', wave, 10)
 %        2d OTF       - mesh (e.g., linepairs/'um')
 %        1d OTF       - mesh (e.g., linepairs/'um')
 %
@@ -109,6 +109,11 @@ uData = [];
 pType = ieParamFormat(pType);
 fNum  = [];
 
+% Defaults
+unit   = 'mm'; % Space is millimeters, but maybe there should be no default
+wList  = wvfGet(wvfP,'wave'); % Wave list is whatever the wvf has
+pRange = Inf;  % Plot range
+
 % Allow the last argument to turn off window opening.
 if ~isempty(varargin) && ischar(varargin{end})
     % The last argument is not empty, and it is a string
@@ -127,7 +132,7 @@ normalizeFlag = ~isempty(strfind(pType, 'normalized'));
 %%
 switch(pType)
     
-    case {'2dpsf', '2dpsfangle', '2dpsfanglenormalized'}
+    case {'psfangle', '2dpsfangle', '2dpsfanglenormalized'}
         % wvfPlot(wvfP, '2d psf angle normalized', unit, ...
         %    waveIdx, plotRangeArcMin);
         if ~isempty(varargin)
@@ -151,24 +156,14 @@ switch(pType)
         
         % Start the plotting
         pData = mesh(samp, samp, psf);
-        % xlabel('Angle');
-        % ylabel('Angle');
-        % zlabel('PSF')
-        % [Note: JNM - If the labels are immediately overwritten, why not
-        % only do it once? Testing by commenting out generic form to see
-        % if anything breaks]
         s = sprintf('Angle (%s)', unit);
-        xlabel(s);
-        ylabel(s);
-        zlabel('PSF amplitude')
+        xlabel(s); ylabel(s); zlabel('PSF amplitude')
         
-        uData.x = samp;
-        uData.y = samp;
-        uData.z = psf;
+        uData.x = samp; uData.y = samp; uData.z = psf;
         set(gcf, 'userdata', uData);
         
-    case {'2dpsfspace', '2dpsfspacenormalized'}
-        % wvfPlot(wvfP, '2d psf space', unit, waveIdx, plotRangeArcMin);
+    case {'psf','2dpsfspace', '2dpsfspacenormalized'}
+        % wvfPlot(wvfP, '2d psf space', ', waveIdx, plotRangeArcMin);
         if ~isempty(varargin)
             [unit, wList, pRange] = wvfReadArg(wvfP, varargin);
         end
@@ -188,9 +183,7 @@ switch(pType)
         
         pData = mesh(samp, samp, psf);
         s = sprintf('Position (%s)', unit);
-        xlabel(s);
-        ylabel(s);
-        zlabel('Relative amplitude')
+        xlabel(s); ylabel(s); zlabel('Relative amplitude')
         
         uData.x = samp;
         uData.y = samp;
@@ -219,20 +212,14 @@ switch(pType)
         
         % Put up the image
         pData = imagesc(samp, samp, psf);
-        colormap(hot);
-        axis image
-        grid(gca, 'on');
+        colormap(hot); axis image; grid(gca, 'on');
         set(gca, 'xcolor', [.5 .5 .5]);
         set(gca, 'ycolor', [.5 .5 .5]);
         s = sprintf('Position (%s)', unit);
-        xlabel(s);
-        ylabel(s);
-        title('Relative amplitude')
+        xlabel(s); ylabel(s); title('Relative amplitude')
         
         % Save the data
-        uData.x = samp;
-        uData.y = samp;
-        uData.z = psf;
+        uData.x = samp; uData.y = samp; uData.z = psf;
         set(gcf, 'userdata', uData);
         
     case {'imagepsfangle'}
@@ -257,22 +244,15 @@ switch(pType)
         
         % Put up the image
         pData =  imagesc(samp, samp, psf);
-        colormap(hot);
-        axis image
-        grid(gca, 'on');
+        colormap(hot); axis image; grid(gca, 'on');
         set(gca, 'xcolor', [.5 .5 .5]);
         set(gca, 'ycolor', [.5 .5 .5]);
         s = sprintf('Position (%s)', unit);
-        xlabel(s);
-        ylabel(s);
-        title('Relative amplitude')
+        xlabel(s); ylabel(s); title('Relative amplitude')
         
         % Save the data
-        uData.x = samp;
-        uData.y = samp;
-        uData.z = psf;
+        uData.x = samp; uData.y = samp; uData.z = psf;
         set(gcf, 'userdata', uData);
-        
         
     case {'1dpsf', '1dpsfangle', '1dpsfanglenormalized'}
         % wvfPlot(wvfP, '1d psf angle', unit, waveIdx, plotRangeArcMin);
@@ -344,11 +324,14 @@ switch(pType)
         end
         
         freq = wvfGet(wvfP, 'otf support', unit, wave);
+        % This is how we calculate the frequency
+        %
         % samp = wvfGet(wvfP, 'samples space', unit, wList);
         % nSamp = length(samp);
         % dx = samp(2) - samp(1);
         % nyquistF = 1 / (2 * dx);   % Line pairs (cycles) per unit space
         % freq = unitFrequencyList(nSamp) * nyquistF;
+        %
         
         % Compute OTF, with DC at center for visualazation.  Not entirely
         % clear why we don't simply get the otf from the wvf structure

--- a/tutorials/t_wavefront/t_wvfMTF.m
+++ b/tutorials/t_wavefront/t_wvfMTF.m
@@ -3,8 +3,16 @@
 %  Calculate and plot the MTF for different defocus values on the standard
 %  human wvf
 % 
-%%
+%% Show the PSF
 wvf = wvfCreate;
 wvf = wvfComputePSF(wvf);
-wvfPlot(wvf,'psf');
+wvfPlot(wvf,'psf','min');
 
+%%
+wvfD = wvfSet(wvf,'zcoeffs',1,{'defocus'});
+wvfD = wvfComputePSF(wvfD);
+wvfPlot(wvfD,'psf','min');
+
+%% Read to compute the MTF/OTF now!
+
+%%

--- a/tutorials/t_wavefront/t_wvfMTF.m
+++ b/tutorials/t_wavefront/t_wvfMTF.m
@@ -1,0 +1,10 @@
+%% t_wvfMTF
+%
+%  Calculate and plot the MTF for different defocus values on the standard
+%  human wvf
+% 
+%%
+wvf = wvfCreate;
+wvf = wvfComputePSF(wvf);
+wvfPlot(wvf,'psf');
+

--- a/tutorials/t_wavefront/t_wvfMTF.m
+++ b/tutorials/t_wavefront/t_wvfMTF.m
@@ -3,6 +3,105 @@
 %  Calculate and plot the MTF for different defocus values on the standard
 %  human wvf
 % 
+
+%% 
+ieInit
+
+%% Base wavefront object
+
+wvf0 = wvfCreate('human');
+wave = 550;
+wvf0 = wvfSet(wvf0, 'measured wavelength', 550);
+wvf0 = wvfSet(wvf0, 'calc wavelengths', 550);
+wvf0 = wvfComputePSF(wvf0);
+
+%{
+pupilDiameterMM = 3;
+zCoefs = wvfLoadThibosVirtualEyes(pupilDiameterMM);
+wave = 550;
+umPerDegree = 300;
+% Create wavefront parameters. Be sure to set both measured and
+% calc pupil size.
+wvfP = wvfCreate('calc wavelengths', wave, 'zcoeffs', zCoefs, ...
+    'name', sprintf('human-%d', pupilDiameterMM), ...
+    'umPerDegree', umPerDegree);
+wvfP = wvfSet(wvfP, 'measured pupil size', pupilDiameterMM);
+wvfP = wvfSet(wvfP, 'calc pupil size', pupilDiameterMM);
+wvfP = wvfComputePSF(wvfP);
+wvf0 = wvfP;
+%}
+%% Vary defocus and plot a slice through the PSF
+
+vcNewGraphWin;
+d = [0 , 0.15, 0.5, 0.7];
+thisL = cell(length(d),1);
+for ii=1:length(d)
+    wvf1 = wvfSet(wvf0,'zcoeffs',d(ii),{'defocus'});
+    wvf1 = wvfComputePSF(wvf1);
+    wvfPlot(wvf1, '1d psf space', 'um', wave, 10, 'nowindow');
+    hold on;
+    thisL{ii} = sprintf('D = %0.2f',d(ii));
+end
+
+hold off
+xlabel('um'); ylabel('Relative amp'); grid on
+legend(thisL);
+
+%% Compare the two PSFs
+
+vcNewGraphWin([],'tall');
+subplot(2,1,1);
+wvfPlot(wvf0, 'psf space', 'um', wave, 10,'no window');
+legend({'D=0'})
+
+thisD = d(3);
+subplot(2,1,2);
+wvf1 = wvfSet(wvf0,'zcoeffs',thisD,{'defocus'});
+wvf1 = wvfComputePSF(wvf1);
+wvfPlot(wvf1, 'psf space', 'um', wave, 10,'no window');
+legend({sprintf('D=%1.1f',thisD)})
+
+%%  Show the impact in OTF/MTF version
+
+vcNewGraphWin;
+for ii=1:length(d)
+    wvf1 = wvfSet(wvf0,'zcoeffs',d(ii),{'defocus'});
+    wvf1 = wvfComputePSF(wvf1);
+    wvfPlot(wvf1, '1d otf angle', 'deg', wave, 100, 'nowindow');
+    hold on;
+    thisL{ii} = sprintf('D = %0.2f',d(ii));
+end
+
+hold off
+xlabel('cycles/deg'); ylabel('Relative amp'); grid on
+legend(thisL);
+
+%% Now plot this with respect to angle (cpd), not space
+
+vcNewGraphWin;
+for ii=1:length(d)
+    wvf1 = wvfSet(wvf0,'zcoeffs',d(ii),{'defocus'});
+    wvf1 = wvfComputePSF(wvf1);
+    wvfPlot(wvf1, '1d otf angle', 'deg', wave, 100, 'nowindow');
+    hold on;
+    thisL{ii} = sprintf('D = %0.1f',d(ii));
+end
+
+hold off
+xlabel('deg'); ylabel('Relative amp'); grid on
+legend(thisL);
+
+%%
+wvfPlot(wvf0, '1d otf angle', 'deg', wave, 100);
+legend({'D=0'})
+
+wvfPlot(wvf1, '1d otf angle', 'deg', wave, 100);
+legend({sprintf('D=%1.1f',d)})
+
+
+% wvfPlot(wvf0, '1d psf angle', 'sec', wave, 100);
+% wvfPlot(wvf0, '2d otf', 'mm', wave, 500)
+
 %% Show the PSF
 wvf = wvfCreate;
 wvf = wvfComputePSF(wvf);
@@ -16,3 +115,6 @@ wvfPlot(wvfD,'psf','min');
 %% Read to compute the MTF/OTF now!
 
 %%
+
+
+        


### PR DESCRIPTION
Trisha and I were  experimenting to understand how defocus impacts the MTF.  We wrote a tutorial, t_wvfMTF because some of the results surprised us.  

Specifically, as we defocus for a diffraction-limited optics a defocus of 0.15 diopters has only a small impact on the MTF.  But when we run the same code using the human optics ('wvf human') the same defocus has a very different and larger effect.  So, a specific amount of defocus does not have the same impact on the MTF for different base Z polynomials.  Maybe we shouldn't have been surprised.

The t_wvfMTF illustrates this effect.

While making the code run, we found some issues that we had to fix up in wvfGet.  And we adjusted wvfPlot.

The ISETBio validations appear to still run correctly.  

In summary, the main changes are

- I have opticsCreate() return the wavefront struct for the human wavefront case.
- We fixed an issue with wvfGet and 'samples spacing'.  That code was not handling distance (meters) and angle (deg) requests correctly.
- We added the t_wvfMTF function.
- We edited the wvfPlot function a bit.
